### PR TITLE
Add Read the Docs configuration for TabNet documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the "docs/" directory with Sphinx
+
+sphinx:
+   configuration: docs/source/conf.py
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3.12"
+  jobs:
+    post_install:
+      - pip install uv
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs --link-mode=copy --frozen --no-group dev


### PR DESCRIPTION
Introduced a .readthedocs.yaml file to configure documentation builds using Sphinx. The configuration supports all document formats and sets the OS to Ubuntu LTS with Python 3.12. Includes a post-install step to sync dependencies with UV.