### PR TITLE
Update Codecov badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![OS](https://img.shields.io/badge/ubuntu-blue?logo=ubuntu)
 ![OS](https://img.shields.io/badge/win-blue?logo=windows)
 ![OS](https://img.shields.io/badge/mac-blue?logo=apple)
-[![codecov](https://codecov.io/gh/DanielAvdar/tabnet/graph/badge.svg?token=N0V9KANTG2)](https://codecov.io/gh/DanielAvdar/tabnet)
+[![codecov](https://codecov.io/gh/DanielAvdar/tabnet/branch/main/graph/badge.svg)](https://codecov.io/gh/DanielAvdar/tabnet/tree/main)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![Last Commit](https://img.shields.io/github/last-commit/DanielAvdar/tabnet/main)
 


### PR DESCRIPTION
Adjusted the Codecov badge URL to point to the main branch for accurate coverage representation. This ensures the badge reflects the latest updates on the primary development branch.