### PR TITLE
Update badge URLs to reflect repository name changes

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,10 +26,10 @@ Welcome to pytorch-tabnet2's documentation!
 .. image:: https://img.shields.io/badge/ubuntu-blue?logo=apple
    :alt: MacOS
 
-.. image:: https://codecov.io/gh/DanielAvdar/pytorch-tabnet2/graph/badge.svg?token=N0V9KANTG2
+.. image:: https://codecov.io/gh/DanielAvdar/tabnet/branch/main/graph/badge.svg
    :alt: Coverage
 
-.. image:: https://img.shields.io/github/last-commit/DanielAvdar/pytorch-tabnet2/main
+.. image:: https://img.shields.io/github/last-commit/DanielAvdar/tabnet/main
    :alt: Last Commit
 
 .. toctree::

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -24,10 +24,10 @@ Introduction
 .. image:: https://img.shields.io/badge/ubuntu-blue?logo=apple
    :alt: MacOS
 
-.. image:: https://codecov.io/gh/DanielAvdar/pytorch-tabnet2/graph/badge.svg?token=N0V9KANTG2
+.. image:: https://codecov.io/gh/DanielAvdar/tabnet/branch/main/graph/badge.svg
    :alt: Coverage
 
-.. image:: https://img.shields.io/github/last-commit/DanielAvdar/pytorch-tabnet2/main
+.. image:: https://img.shields.io/github/last-commit/DanielAvdar/tabnet/main
    :alt: Last Commit
 
 


### PR DESCRIPTION
Replaced outdated badge links that referenced "pytorch-tabnet2" with updated links for "tabnet". This ensures correct badge functionality and alignment with the current repository structure.