### PR TITLE
Add `pre-commit install` step to Makefile install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: install
 install:
 	uv sync --all-extras --all-groups --frozen
 	uv pip install pre-commit
-
+	uv run pre-commit install
 
 install-docs:
 	uv sync --group docs --frozen --no-group dev


### PR DESCRIPTION
Ensure `uv run pre-commit install` is executed during installation across multiple projects. This change guarantees pre-commit hooks are properly installed, improving development workflows and code quality consistency.